### PR TITLE
Minor fix: fix wrong, and clarify ambiguous, documentation. One function parameter rename.

### DIFF
--- a/src/UstepperS32.cpp
+++ b/src/UstepperS32.cpp
@@ -4,7 +4,7 @@
 *      	Date: 		December 27th, 2021  	                                    			*
 *      	Authors: 	Thomas Hørring Olsen                                   					*
 *					Emil Jacobsen															*
-*                                                   										*	
+*                                                   										*
 *********************************************************************************************
 *	(C) 2020																				*
 *																							*
@@ -43,7 +43,7 @@ UstepperS32 *ptr;
 UstepperS32::UstepperS32() : driver(), encoder(), dropin()
 {
 	ptr = this;
-	
+
 	this->microSteps = 256;
 
 	this->setMaxAcceleration(2000.0, false);
@@ -63,7 +63,7 @@ UstepperS32::UstepperS32(float acceleration, float velocity) : driver(), encoder
 }
 
 void UstepperS32::setup(uint8_t mode,
-						uint16_t stepsPerRevolution,
+						uint16_t fullstepsPerRevolution,
 						float pTerm,
 						float iTerm,
 						float dTerm,
@@ -72,14 +72,14 @@ void UstepperS32::setup(uint8_t mode,
 						uint8_t invert,
 						uint8_t runCurrent,
 						uint8_t holdCurrent)
-{	
+{
 	this->encoder.init();
 	this->driver.init();
 
 	dropinCliSettings_t tempSettings;
 	this->pidDisabled = 1;
-	
-	this->fullSteps = stepsPerRevolution;
+
+	this->fullSteps = fullstepsPerRevolution;
 	this->angleToStep = (float)this->fullSteps * (float)this->microSteps / 360.0;
 	this->rpmToVelocity = (float)(279620.267 * fullSteps * microSteps) / (DRIVERCLOCKFREQ);
 	this->stepsPerSecondToRPM = 60.0 / (this->microSteps * this->fullSteps);
@@ -88,14 +88,14 @@ void UstepperS32::setup(uint8_t mode,
 	this->stepTime = 16777216.0 / DRIVERCLOCKFREQ; // 2^24/DRIVERCLOCKFREQ
 	this->rpmToVel = (this->fullSteps * this->microSteps) / (60.0 / this->stepTime);
 	this->velToRpm = 1.0 / this->rpmToVel;
-	
+
 	this->driver.setDeceleration((uint32_t)(this->maxDeceleration));
 	this->driver.setAcceleration((uint32_t)(this->maxAcceleration));
 
 	this->setCurrent(40.0);
 	this->setHoldCurrent(40.0);
 
-	
+
 	if (setHome == true)
 	{
 		encoder.setHome();
@@ -106,7 +106,7 @@ void UstepperS32::setup(uint8_t mode,
 		this->checkOrientation(10);
 	}
 	this->mode = mode;
-	
+
 	mainTimerInit();
 	if (mode == DROPIN)
 	{
@@ -146,12 +146,12 @@ void UstepperS32::checkOrientation(float distance)
 	uint8_t inverted = 0;
 	uint8_t noninverted = 0;
 	bool pidEnabled = this->mode == NORMAL ? false : true;
-	
+
 	if (pidEnabled)
 	{
 		this->disablePid();
 	}
-	
+
 	this->shaftDir = 0;
 	this->driver.setShaftDirection(this->shaftDir);
 
@@ -193,7 +193,7 @@ void UstepperS32::setMaxVelocity(float velocity, bool applyToDriver)
 	velocity = abs(velocity) * VELOCITYCONVERSION;
 
 	this->maxVelocity = velocity;
-	
+
 	if (applyToDriver == false)
 	{
 		return;
@@ -213,7 +213,7 @@ void UstepperS32::setMaxAcceleration(float acceleration, bool applyToDriver)
 	{
 		return;
 	}
-	
+
 	// Steps per second, has to be converted to microsteps
 	this->driver.setAcceleration((uint32_t)(this->maxAcceleration));
 }
@@ -229,7 +229,7 @@ void UstepperS32::setMaxDeceleration(float deceleration, bool applyToDriver)
 	{
 		return;
 	}
-	
+
 	// Steps per second, has to be converted to microsteps
 	this->driver.setDeceleration((uint32_t)(this->maxDeceleration));
 }
@@ -503,7 +503,7 @@ void UstepperS32::setHoldCurrent(double current)
 
 	driver.updateCurrent();
 }
-extern "C" uint8_t getUstepperMode() 
+extern "C" uint8_t getUstepperMode()
 {
 	return ptr->mode;
 }

--- a/src/UstepperS32.h
+++ b/src/UstepperS32.h
@@ -87,7 +87,7 @@ class UstepperS32
 	 * @param[in]  dTerm            	The differential coefficent of the DROPIN PID
 	 *                              	controller
 	 * @param[in]  dropinStepSize		number of steps per fullstep, send from
-	 *									external dropin controller   
+	 *									external dropin controller
 	 * @param[in]  setHome          	When set to true, the encoder position is
 	 *									Reset. When set to false, the encoder
 	 *									position is not reset.
@@ -98,7 +98,7 @@ class UstepperS32
 	 * @param[in]  holdCurrent      	Sets the current (in percent) to use while motor is NOT running
 	 */
 	void setup(uint8_t mode = NORMAL,
-			   uint16_t stepsPerRevolution = 200,
+			   uint16_t fullstepsPerRevolution = 200,
 			   float pTerm = 10,
 			   float iTerm = 0.2,
 			   float dTerm = 0.0,
@@ -111,7 +111,7 @@ class UstepperS32
 	/**
 	 * @brief      Set the velocity in rpm
 	 *
-	 *             This function lets the user set the velocity of the motor in rpm. 
+	 *             This function lets the user set the velocity of the motor in rpm.
 	 *             A negative value switches direction of the motor.
 	 *
 	 * @param[in]  rpm  - The velocity in rotations per minute
@@ -121,34 +121,34 @@ class UstepperS32
 	/**
 	 * @brief      Get the RPM from driver
 	 *
-	 *             This function returns the driver velocity of the motor 
+	 *             This function returns the driver velocity of the motor
 	 *
 	 * @return     The velocity in rpm
 	 */
 	float getDriverRPM(void);
 
 	/**
-	 * @brief      Make the motor perform a predefined number of steps
+	 * @brief      Make the motor perform a predefined number of microsteps
 	 *
 	 *             This function makes the motor perform a predefined number of
 	 *             steps, using the acceleration profile. The motor will accelerate
-	 *             at the rate set by setMaxAcceleration(), decelerate at the rate set by setMaxDeceleration() and eventually reach the speed set
-	 *             by setMaxVelocity() function. The direction of rotation
-	 *             is set by the sign of the commanded steps to perform
+	 *             at the rate set by setMaxAcceleration(), decelerate at the rate set by setMaxDeceleration()
+     *             and eventually reach the speed set by setMaxVelocity() function.
+     *             The direction of rotation is set by the sign of the commanded microsteps to perform.
 	 *
-	 * @param[in]      steps     -	Number of steps to be performed. an input value of
-	 *								300 makes the motor go 300 steps in CW direction, and
-	 *								an input value of -300 makes the motor move 300 steps
+	 * @param[in]      microsteps -	Number of microsteps to be performed. an input value of
+	 *								300 makes the motor go 300 microsteps in CW direction, and
+	 *								an input value of -300 makes the motor move 300 microsteps
 	 *								in CCW direction.
 	 */
-	void moveSteps(int32_t steps);
+	void moveSteps(int32_t microsteps);
 
 	/**
 	 * @brief      	Makes the motor rotate a specific angle relative to the current position
 	 *
-	 *              This function makes the motor a rotate by a specific angle relative to 
+	 *              This function makes the motor a rotate by a specific angle relative to
 	 *			    the current position, using the acceleration profile. The motor will accelerate
-	 *              at the rate set by setMaxAcceleration(), decelerate at the rate set by 
+	 *              at the rate set by setMaxAcceleration(), decelerate at the rate set by
 	 *				setMaxDeceleration() and eventually reach the speed set
 	 *              by setMaxVelocity() function. The direction of rotation
 	 *              is set by the sign of the commanded angle to move
@@ -163,16 +163,16 @@ class UstepperS32
 	/**
 	 * @brief      	Makes the motor rotate to a specific absolute angle
 	 *
-	 *              This function makes the motor a rotate to a specific angle, 
+	 *              This function makes the motor a rotate to a specific angle,
 	 *			    using the acceleration profile. The motor will accelerate
-	 *              at the rate set by setMaxAcceleration(), decelerate at the rate set by 
+	 *              at the rate set by setMaxAcceleration(), decelerate at the rate set by
 	 *				setMaxDeceleration() and eventually reach the speed set
 	 *              by setMaxVelocity() function. The direction of rotation
 	 *              is set by the sign of the commanded angle to move
 	 *
 	 * @param[in]  	    angle     -	Angle to move to. An input value of
-	 *								300 makes the motor go to absolute 300 degrees, 
-	 *								and an input value of -300 makes the motor move 
+	 *								300 makes the motor go to absolute 300 degrees,
+	 *								and an input value of -300 makes the motor move
 	 *								to absolute -300 degrees.
 	 */
 	void moveToAngle(float angle);
@@ -188,12 +188,12 @@ class UstepperS32
 	 *					VELOCITY_REACHED - has last commanded velocity been reached?
 	 *					STANDSTILL - Are the motor currently stopped?
 	 *					STALLGUARD2 - Has the stallguard been trickered?
-	 *					
+	 *
 	 *
 	 * @return     The angle moved.
 	 */
 	bool getMotorState(uint8_t statusType = POSITION_REACHED);
-	
+
 	/**
 	 * @brief      Make the motor rotate continuously
 	 *
@@ -210,7 +210,7 @@ class UstepperS32
 	 * @return     The angle moved in degrees.
 	 */
 	float angleMoved(void);
-	
+
 	/**
 	 * @brief      Set motor output current.
 	 *
@@ -232,35 +232,35 @@ class UstepperS32
 	/**
 	 * @brief      Set the maximum acceleration of the stepper motor.
 	 *
-	 *             This function lets the user set the max acceleration used 
+	 *             This function lets the user set the max acceleration used
 	 *             by the stepper driver.
 	 *
-	 * @param[in]      acceleration  - Maximum acceleration in steps/s^2
+	 * @param[in]      acceleration  - Maximum acceleration in fullsteps/s^2
 	 */
 	void setMaxAcceleration(float acceleration, bool applyToDriver = true);
 
 	/**
 	 * @brief      Set the maximum deceleration of the stepper motor.
 	 *
-	 *             This function lets the user set the max deceleration used 
+	 *             This function lets the user set the max deceleration used
 	 *             by the stepper driver.
 	 *
-	 * @param[in]      deceleration  - Maximum deceleration in steps/s^2
+	 * @param[in]      deceleration  - Maximum deceleration in fullsteps/s^2
 	 */
 	void setMaxDeceleration(float deceleration, bool applyToDriver = true);
 
 	/**
 	 * @brief      Set the maximum velocity of the stepper motor.
 	 *
-	 *             This function lets the user set the max velocity used 
+	 *             This function lets the user set the max velocity used
 	 *             by the stepper driver.
 	 *
-	 * @param[in]      velocity  - Maximum velocity in steps/s
+	 * @param[in]      velocity  - Maximum velocity in fullsteps/s
 	 */
 	void setMaxVelocity(float velocity, bool applyToDriver = true);
 
 	/**
-	 * @brief      Enable TMC5130 StallGuard 
+	 * @brief      Enable TMC5130 StallGuard
 	 *
 	 *             	This function enables the builtin stallguard offered from TMC5130 stepper driver.
 	 * 				The threshold should be tuned as to trigger stallguard before a step is lost.
@@ -281,7 +281,7 @@ class UstepperS32
 	void clearStall(void);
 
 	/**
-	 * @brief      	This method returns a bool variable indicating wether the motor is stalled or not. 
+	 * @brief      	This method returns a bool variable indicating wether the motor is stalled or not.
 	 * 				Uses the default stallguard threshold, unless this has been changed by .enableStallguard()
 	 *
 	 * @return     	0 = not stalled, 1 = stalled
@@ -290,29 +290,29 @@ class UstepperS32
 
 	/**
 	 * @brief      	This method returns a bool variable indicating wether the motor is stalled or not.
-	 * 				The stallguard is sensitive to the speed of the motor, as the torque available is a 
-	 * 				function of the speed. Therefore, it is necessary to change the treshold according 
+	 * 				The stallguard is sensitive to the speed of the motor, as the torque available is a
+	 * 				function of the speed. Therefore, it is necessary to change the treshold according
 	 * 				to the application. A higher treshold makes the stallguard less sensitive to external
 	 * 				loads, meaning that, the higher the application speed, the higher the treshold has to
 	 * 				be for the stall guard to perform well
 	 *
 	 * @param[in]   threshold  -  Threshold for stallguard. A value between -64 and +63
-	 * 
-	 * @return     	0 = not stalled, 1 = stalled		
+	 *
+	 * @return     	0 = not stalled, 1 = stalled
 	*/
 	bool isStalled(int8_t threshold);
 
 	/**
-	 * @brief      	
+	 * @brief
 	 *
 	 * @param[in]   mode  -  this parameter specifies how the motor should brake during standstill.
 	 * 				available modes:
 	 * 				FREEWHEELBRAKE - This will result in no holding torque at standstill
-	 *				COOLBRAKE 1 - This will make the motor brake by shorting the two bottom FET's of the H-Bridge. This will provide less holding torque, but will significantly reduce driver heat 
+	 *				COOLBRAKE 1 - This will make the motor brake by shorting the two bottom FET's of the H-Bridge. This will provide less holding torque, but will significantly reduce driver heat
 	 *				HARDBRAKE 2 - This will make the motor brake by sending the full specified current through the coils. This will provide high holding torque, but will make the driver (and motor) dissipate power
-	 * 
+	 *
 	 * @param[in]   brakeCurrent (optional) -  if HARDBRAKE is use as mode, this argument can set the current to use for braking (0-100% of 2A).
-	 * 				If argument is not specified, the motor will brake with 25% of max current	
+	 * 				If argument is not specified, the motor will brake with 25% of max current
 	*/
 	void setBrakeMode(uint8_t mode, float brakeCurrent = 25.0);
 
@@ -356,9 +356,9 @@ class UstepperS32
 	 * @param[in]  	dir  Direction to search for limit
 	 *
 	 * @param[in]   rpm   RPM of the motor while searching for limit
-	 * 
+	 *
 	 * @param[in]  	threshold  Sensitivity of stall detection (-64 to +63), low is more sensitive
-	 * 
+	 *
 	 * @param[in]  	Timeout in milliseconds to exit function if homing doesnt behave as expected
 	 *
 	 * @return 		Degrees turned from calling the function, till end was reached
@@ -376,22 +376,22 @@ class UstepperS32
 	 *						or "SOFT" for deceleration phase.
 	 */
 	void stop(bool mode = HARD);
-	
+
 	/**
 	 * @brief      This method returns the current PID error
 	 * @return     PID error (float)
 	 */
 	float getPidError(void); //*delete*/
-	
+
 	/**
-	 * @brief      	This method is used to check the orientation of the motor connector. 
+	 * @brief      	This method is used to check the orientation of the motor connector.
 	 *
 	 * @param[in]  	distance - the amount of degrees the motor shaft should rotate during orientation determination.
-	 *			
+	 *
 	 */
 
 	void checkOrientation(float distance = 10);
-	
+
   private:
 	friend void mainTimerCallback();
 	friend void dropInStepInputEXTI();
@@ -403,18 +403,19 @@ class UstepperS32
 	float rpmToVel;
 	float velToRpm;
 
-	/** This variable contains the maximum velocity in steps/s, the motor is
-	 * allowed to reach at any given point. The user of the library can
-	 * set this by use of the setMaxVelocity()
-	 */
+	/** This variable contains the maximum velocity, the motor is allowed to reach at any given point.
+     *  The variable is in units of ( 1.0 / ( 2^24 * |f_CLK| ) ) * ( microsteps / second ).
+     *  The user of the library can set this by use of the setMaxVelocity() function,
+     *  which takes in values with units of ( fullsteps / s ). */
 	float maxVelocity;
 
-	/** This variable contains the maximum acceleration in steps/s to be used. The
-	 * can be set and read by the user of the library using the
-	 * functions setMaxAcceleration()
-	 */
+	/** These variables contain the maximum acceleration/deceleration in steps/s to be used. The
+     *  The variables are in units of ( 2^41 / |f_CLK|^2 ) * ( microsteps / s^2 ).
+	 *  can be set and read by the user of the library using the setMaxAcceleration() and setMaxDeceleration() functions,
+     *  which take in values with units of ( fullsteps / s^2 ). */
 	float maxAcceleration;
 	float maxDeceleration;
+
 	float rpmToVelocity;
 	float angleToStep;
 
@@ -434,7 +435,7 @@ class UstepperS32
 	0 = OK, 1 = stalled */
 	volatile bool stall;
 	// SPI functions
-	volatile float currentPidError; 
+	volatile float currentPidError;
 
 	/** This variable holds the default stall threshold, but can be updated by the user. */
 	int8_t stallThreshold = 4;

--- a/src/UstepperS32.h
+++ b/src/UstepperS32.h
@@ -410,7 +410,7 @@ class UstepperS32
 	float maxVelocity;
 
 	/** These variables contain the maximum acceleration/deceleration in steps/s to be used. The
-     *  The variables are in units of ( 2^41 / |f_CLK|^2 ) * ( microsteps / s^2 ).
+     *  The variables are in units of ( |f_CLK|^2 / 2^41 ) * ( microsteps / s^2 ).
 	 *  can be set and read by the user of the library using the setMaxAcceleration() and setMaxDeceleration() functions,
      *  which take in values with units of ( fullsteps / s^2 ). */
 	float maxAcceleration;


### PR DESCRIPTION
Piggybacking off [#11]. `maxVelocity` was in particular something I burned myself on. I'm pretty sure the changes are correct, but please review.

For the units passed to the TMC5130A driver, I opted for the form that separates the unit into a constant factor, and the actual units, as opposed to defining a reference time value, which is how the TMC5130A datasheet presents it.

I've refrained from changing any variable names, with the exception of a single function parameter, but I would generally recommend changing a few of the variable names that are a bit ambiguous to be more explicit.

Aside from that it appears my text editor also automatically deleted some tab-characters on empty lines, newlines at the end of files and trailing whitespace in general.