### PR TITLE
ci: user-issue tracker for planning Project

### DIFF
--- a/.github/ISSUE_TEMPLATE/child-issue.md
+++ b/.github/ISSUE_TEMPLATE/child-issue.md
@@ -1,0 +1,30 @@
+---
+name: Planning child issue
+about: Concrete work item that belongs to a planning epic
+title: "[<epic-slug>] "
+labels: planning
+assignees: ''
+---
+
+## Parent epic
+Part of zenpai45/ustepperSTM32.plan#<N>
+<!-- Replace <N> with the epic issue number. GitHub renders this as a timeline reference on the epic. -->
+
+## What
+<!-- One sentence: what this delivers. -->
+
+## Where
+<!-- File(s) / directory this lands in. See sibling cheat sheet in ../ustepperSTM32.plan/CLAUDE.md. -->
+-
+
+## Acceptance criteria
+- [ ]
+
+## Public API impact
+- [ ] None — internal only
+- [ ] Public API added/changed — `keywords.txt` updated
+- [ ] Public API added/changed — example sketch added/updated under `examples/`
+- [ ] Public API added/changed — doxygen on header declarations
+
+## Testing
+<!-- Compile against which variant, which example to run, any on-hardware checks. -->

--- a/.github/workflows/add-user-issues-to-project.yml
+++ b/.github/workflows/add-user-issues-to-project.yml
@@ -1,0 +1,15 @@
+name: Add user issues to Project
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add:
+    # Skip issues filed by our own planning workflow (they carry the `planning` label).
+    if: ${{ !contains(github.event.issue.labels.*.name, 'planning') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/zenpai45/projects/1
+          github-token: ${{ secrets.PROJECT_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# uStepperS32 — library
+
+Arduino library for the **uStepper S32** board. Target MCU is STM32F401xC (Cortex-M4F); hardware is Trinamic **TMC5130** stepper driver + Infineon **TLE5012B** magnetic angle encoder, both on SPI.
+
+Planning, roadmap, and multi-repo coordination live in the planning repo: `../ustepperSTM32.plan` (GitHub: `zenpai45/ustepperSTM32.plan`). Issues in this repo are children of planning epics — title prefix `[<epic-slug>]`, body references the parent.
+
+## Structure
+
+- `src/UstepperS32.{h,cpp}` — top-level user-facing class; this is the Arduino API surface
+- `src/HAL/` — gpio, spi, timer glue (direct MCU / stm32duino)
+- `src/peripherals/` — chip drivers (`TMC5130.{h,cpp}`, `TLE5012B.{h,cpp}`); new ICs go here
+- `src/utils/` — math and helpers
+- `src/callbacks/` — callback dispatch
+- `examples/<name>/<name>.ino` — one folder per example; every public feature ships one
+- `keywords.txt` — Arduino IDE syntax highlighting; update on public API changes
+- `library.properties` — Arduino library metadata (bump `version=` on release)
+
+## Conventions
+
+- **API style**: Arduino-idiomatic — `begin()`, `setRPM()`, `moveSteps()` etc.; setters rather than config structs; initialization in `setup()`.
+- **Header/source pairs**: each class/module gets matching `.h` / `.cpp`.
+- **Public API changes require**: updated `keywords.txt`, an example sketch demonstrating the feature, and doxygen comments on the header declarations.
+- **Hardware access** goes through `src/HAL/`. Peripheral drivers (`TMC5130`, `TLE5012B`) should call HAL, not poke registers directly.
+- **Licence is CC-BY-NC-SA 4.0** (non-commercial). Do not absorb code under incompatible licences (GPL, proprietary) without explicit approval. The Modbus RTU code has its own BSD-3 notice — preserve it verbatim.
+
+## CI
+
+`.github/workflows/ci.yml` runs Arduino compile checks across examples. Keep it green before requesting review.
+
+## Before finishing a refactor
+
+If top-level `src/` layout changes (a subdirectory added/removed/renamed, or the boundary between `HAL` / `peripherals` / `utils` / `callbacks` shifts) **update the sibling cheat sheet in `../ustepperSTM32.plan/CLAUDE.md` in the same PR**. That cheat sheet is intentionally coarse (top-level buckets only); internal reorganisation below that level does not require a sync.


### PR DESCRIPTION
Auto-adds `issues.opened` events (without the `planning` label) to zenpai45's Project #1 for triage.

Requires `PROJECT_PAT` repo secret — a fine-grained PAT with `Projects: read and write` on user `zenpai45` and `Issues: read` on this repo. Thomas sets this separately.